### PR TITLE
Fixed the "distance not showing" bug and more

### DIFF
--- a/src/PingDistance/Plugin.cs
+++ b/src/PingDistance/Plugin.cs
@@ -11,8 +11,8 @@ namespace PingDistance;
 public partial class Plugin : BaseUnityPlugin
 {
     internal static ManualLogSource Log { get; private set; } = null!;
-    private static GameObject? templateText;
-    private static readonly Dictionary<Character, GameObject> distanceInstances = [];
+    private static GameObject? TemplateText;
+    private static readonly Dictionary<Character, GameObject> DistanceInstances = [];
     private static GameObject? PingDistanceCanvas;
 
     private void Awake()
@@ -31,7 +31,7 @@ public partial class Plugin : BaseUnityPlugin
         if (PingDistanceCanvas == null)
         {
             CreatePingDistanceCanvas();
-            distanceInstances.Clear();
+            DistanceInstances.Clear();
         }
     }
 
@@ -39,30 +39,30 @@ public partial class Plugin : BaseUnityPlugin
     [HarmonyPrefix]
     private static void PointPinger_ReceivePoint_Rpc_Prefix(PointPinger __instance, ref Vector3 point, ref Vector3 hitNormal)
     {
-        if (PingDistanceCanvas == null || templateText == null)
+        if (PingDistanceCanvas == null || TemplateText == null)
         {
             Log.LogError("PingDistanceCanvas or templateText is not instantiated");
             return;
         }
 
-        Character character = __instance.character;
-        Vector3 position = point + hitNormal;
+        Character Character = __instance.character;
+        Vector3 Position = point + hitNormal;
 
-        if (distanceInstances.TryGetValue(character, out GameObject? oldInstance) && oldInstance != null)
+        if (DistanceInstances.TryGetValue(Character, out GameObject? OldInstance) && OldInstance != null)
         {
-            Destroy(oldInstance);
+            Destroy(OldInstance);
         }
 
-        GameObject newInstance = Instantiate(templateText, PingDistanceCanvas.transform);
-        newInstance.SetActive(true);
+        GameObject NewInstance = Instantiate(TemplateText, PingDistanceCanvas.transform);
+        NewInstance.SetActive(true);
 
-        PingDistance distanceComponent = newInstance.GetComponent<PingDistance>();
-        distanceComponent.position = position;
-        distanceComponent.character = character;
+        PingDistance DistanceComponent = NewInstance.GetComponent<PingDistance>();
+        DistanceComponent.Position = Position;
+        DistanceComponent.Character = Character;
 
-        distanceInstances[character] = newInstance;
+        DistanceInstances[Character] = NewInstance;
 
-        Destroy(newInstance, 1.25f);
+        Destroy(NewInstance, 1.25f);
     }
 
     private static void CreatePingDistanceCanvas()
@@ -72,22 +72,22 @@ public partial class Plugin : BaseUnityPlugin
         PingDistanceCanvas = Instantiate(NamesCanvas, GUIManager.transform);
         PingDistanceCanvas.name = "Canvas_PingDistance";
 
-        if (PingDistanceCanvas.TryGetComponent<UIPlayerNames>(out UIPlayerNames component))
-            Destroy(component);
+        if (PingDistanceCanvas.TryGetComponent<UIPlayerNames>(out UIPlayerNames Component))
+            Destroy(Component);
 
-        templateText = PingDistanceCanvas.transform.GetChild(0).gameObject;
-        Destroy(templateText.transform.GetChild(0).gameObject);
-        if (templateText.TryGetComponent<PlayerName>(out PlayerName? nameComponent))
+        TemplateText = PingDistanceCanvas.transform.GetChild(0).gameObject;
+        Destroy(TemplateText.transform.GetChild(0).gameObject);
+        if (TemplateText.TryGetComponent<PlayerName>(out PlayerName? nameComponent))
             Destroy(nameComponent);
 
-        templateText.name = "DistanceText";
-        templateText.AddComponent<PingDistance>();
-        templateText.SetActive(false);
+        TemplateText.name = "DistanceText";
+        TemplateText.AddComponent<PingDistance>();
+        TemplateText.SetActive(false);
 
         for (int i = 0; i < PingDistanceCanvas.transform.childCount; i++)
         {
-            GameObject child = PingDistanceCanvas.transform.GetChild(i).gameObject;
-            if (child.name.Contains("UI_PlayerName")) Destroy(child);
+            GameObject Child = PingDistanceCanvas.transform.GetChild(i).gameObject;
+            if (Child.name.Contains("UI_PlayerName")) Destroy(Child);
         }
 
         Log.LogInfo("PingDistanceCanvas created");
@@ -96,24 +96,24 @@ public partial class Plugin : BaseUnityPlugin
 
 public class PingDistance : MonoBehaviour
 {
-    public Vector3 position;
-    public Character? character;
-    private TextMeshProUGUI? tmp;
+    public Vector3 Position;
+    public Character? Character;
+    private TextMeshProUGUI? TMP;
 
     void LateUpdate()
     {
         if (Camera.main == null) return;
 
-        Color color = character != null ? character.refs.customization.PlayerColor : Color.white;
-        float distance = Mathf.Round(Vector3.Distance(position, Camera.main.transform.position));
-        float angle = Vector3.Angle(Camera.main.transform.forward, position - Camera.main.transform.position);
-        if (tmp == null) tmp = GetComponentInChildren<TextMeshProUGUI>();
+        Color color = Character != null ? Character.refs.customization.PlayerColor : Color.white;
+        float distance = Mathf.Round(Vector3.Distance(Position, Camera.main.transform.position));
+        float angle = Vector3.Angle(Camera.main.transform.forward, Position - Camera.main.transform.position);
+        if (TMP == null) TMP = GetComponentInChildren<TextMeshProUGUI>();
 
-        transform.position = Camera.main.WorldToScreenPoint(position);
+        transform.position = Camera.main.WorldToScreenPoint(Position);
 
-        tmp.fontSize = 30f;
-        tmp.color = color;
-        tmp.text = $"{distance}m";
-        tmp.gameObject.SetActive(angle < 90f);
+        TMP.fontSize = 30f;
+        TMP.color = color;
+        TMP.text = $"{distance}m";
+        TMP.gameObject.SetActive(angle < 90f);
     }
 }

--- a/src/PingDistance/Plugin.cs
+++ b/src/PingDistance/Plugin.cs
@@ -1,6 +1,6 @@
 ﻿using BepInEx;
 using BepInEx.Logging;
-using System.Reflection;
+using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
 using TMPro;
@@ -11,101 +11,109 @@ namespace PingDistance;
 public partial class Plugin : BaseUnityPlugin
 {
     internal static ManualLogSource Log { get; private set; } = null!;
-    private static GameObject? distanceText;
-    private static GameObject? distanceInstance;
+    private static GameObject? templateText;
+    private static readonly Dictionary<Character, GameObject> distanceInstances = [];
     private static GameObject? PingDistanceCanvas;
 
     private void Awake()
     {
         Log = Logger;
 
-        Log.LogInfo($"Plugin {Name} is loaded!");
+        Log.LogInfo($"Plugin {Name} Version {Version} is loaded!");
 
         Harmony.CreateAndPatchAll(typeof(Plugin));
     }
 
+    [HarmonyPatch(typeof(PointPinger), nameof(PointPinger.Awake))]
     [HarmonyPrefix]
-    [HarmonyPatch(typeof(PointPinger), nameof(PointPinger.ReceivePoint_Rpc))]
-    private static void PingDistancePatch(PointPinger __instance, ref Vector3 __0, ref Vector3 __1)
+    private static void PointPinger_Awake_Prefix(PointPinger __instance)
     {
-        Vector3 point = __0;
-        Vector3 hitNormal = __1;
-
-        Vector3 position = new Vector3(point.x + hitNormal.x, point.y + hitNormal.y, point.z + hitNormal.z);
-
-        PingDistance distanceComponent;
-
         if (PingDistanceCanvas == null)
         {
-            GameObject GUIManager = GameObject.Find("GAME/GUIManager");
-            GameObject NamesCanvas = GameObject.Find("GAME/GUIManager/Canvas_Names");
-            PingDistanceCanvas = Instantiate(NamesCanvas, GUIManager.transform);
-            PingDistanceCanvas.name = "Canvas_PingDistance";
+            CreatePingDistanceCanvas();
+            distanceInstances.Clear();
+        }
+    }
 
-            UIPlayerNames component;
-            PingDistanceCanvas.TryGetComponent<UIPlayerNames>(out component);
-            Destroy(component);
-
-            Log.LogInfo(PingDistanceCanvas.transform.childCount);
-            distanceText = PingDistanceCanvas.transform.GetChild(0).gameObject;
-            distanceText.name = "DistanceText";
-
-            for (int i = 0; i < PingDistanceCanvas.transform.childCount; i++)
-            {
-                GameObject child = PingDistanceCanvas.transform.GetChild(i).gameObject;
-                if (child.name.Contains("UI_PlayerName")) Destroy(child);
-            }
-
-            PlayerName nameComponent;
-            distanceText.TryGetComponent<PlayerName>(out nameComponent);
-            Destroy(nameComponent);
-
-            Destroy(distanceText.transform.GetChild(0).gameObject);
-
-            distanceText.AddComponent<PingDistance>();
-            distanceText.SetActive(false);
+    [HarmonyPatch(typeof(PointPinger), nameof(PointPinger.ReceivePoint_Rpc))]
+    [HarmonyPrefix]
+    private static void PointPinger_ReceivePoint_Rpc_Prefix(PointPinger __instance, ref Vector3 point, ref Vector3 hitNormal)
+    {
+        if (PingDistanceCanvas == null || templateText == null)
+        {
+            Log.LogError("PingDistanceCanvas or templateText is not instantiated");
+            return;
         }
 
-        if (distanceText == null) return;
+        Character character = __instance.character;
+        Vector3 position = point + hitNormal;
 
-        if (distanceInstance != null) Destroy(distanceInstance);
+        if (distanceInstances.TryGetValue(character, out GameObject? oldInstance) && oldInstance != null)
+        {
+            Destroy(oldInstance);
+        }
 
-        distanceInstance = Instantiate(distanceText, PingDistanceCanvas.transform);
-        distanceInstance.SetActive(true);
+        GameObject newInstance = Instantiate(templateText, PingDistanceCanvas.transform);
+        newInstance.SetActive(true);
 
-        distanceComponent = distanceInstance.GetComponent<PingDistance>();
+        PingDistance distanceComponent = newInstance.GetComponent<PingDistance>();
         distanceComponent.position = position;
-        distanceComponent.character = __instance.character;
+        distanceComponent.character = character;
 
-        Destroy(distanceInstance, 1.25f);
+        distanceInstances[character] = newInstance;
+
+        Destroy(newInstance, 1.25f);
+    }
+
+    private static void CreatePingDistanceCanvas()
+    {
+        GameObject GUIManager = GameObject.Find("GAME/GUIManager");
+        GameObject NamesCanvas = GameObject.Find("GAME/GUIManager/Canvas_Names");
+        PingDistanceCanvas = Instantiate(NamesCanvas, GUIManager.transform);
+        PingDistanceCanvas.name = "Canvas_PingDistance";
+
+        if (PingDistanceCanvas.TryGetComponent<UIPlayerNames>(out UIPlayerNames component))
+            Destroy(component);
+
+        templateText = PingDistanceCanvas.transform.GetChild(0).gameObject;
+        Destroy(templateText.transform.GetChild(0).gameObject);
+        if (templateText.TryGetComponent<PlayerName>(out PlayerName? nameComponent))
+            Destroy(nameComponent);
+
+        templateText.name = "DistanceText";
+        templateText.AddComponent<PingDistance>();
+        templateText.SetActive(false);
+
+        for (int i = 0; i < PingDistanceCanvas.transform.childCount; i++)
+        {
+            GameObject child = PingDistanceCanvas.transform.GetChild(i).gameObject;
+            if (child.name.Contains("UI_PlayerName")) Destroy(child);
+        }
+
+        Log.LogInfo("PingDistanceCanvas created");
     }
 }
 
 public class PingDistance : MonoBehaviour
 {
-    public float scaleFactor = 0.3f;
     public Vector3 position;
     public Character? character;
-
     private TextMeshProUGUI? tmp;
 
     void LateUpdate()
     {
         if (Camera.main == null) return;
-        if (tmp == null) tmp = GetComponentInChildren<TextMeshProUGUI>();
-        
 
+        Color color = character != null ? character.refs.customization.PlayerColor : Color.white;
+        float distance = Mathf.Round(Vector3.Distance(position, Camera.main.transform.position));
         float angle = Vector3.Angle(Camera.main.transform.forward, position - Camera.main.transform.position);
-        tmp.gameObject.SetActive(angle < 90f);
-
-        
-        tmp.fontSize = 30f;
+        if (tmp == null) tmp = GetComponentInChildren<TextMeshProUGUI>();
 
         transform.position = Camera.main.WorldToScreenPoint(position);
 
-        float distance = Vector3.Distance(position, Camera.main.transform.position);
-        distance = Mathf.Round(distance);
-
-        tmp.text = distance.ToString() + "m";
+        tmp.fontSize = 30f;
+        tmp.color = color;
+        tmp.text = $"{distance}m";
+        tmp.gameObject.SetActive(angle < 90f);
     }
 }


### PR DESCRIPTION
Heii, loved the little idea of your mod but also had issues with it not consistently working #1 . 
So I worked on a fix for it, test it and submitting now this pull request.

You can replicate the issue if u do this:
- Create a lobby
- Invite a friend
- Look at the friends nameplate
- Look away from it, so its not longer active
- Ping somewhere
- **_The distance is not there?_**


It only works if u have a nameplate visible in the UI when creating the PingDistanceCanvas on the first ping or if you are alone in the lobby/play solo. Somehow it affects the template GameObject in some weird way.
I cannot explain why, but i got a neat workaround. When the PingPointer Instance is initiated, the PingDistanceCanvas is immediately created before a nameplate can be "changed" (like playing solo).

I also refactored the code a bit for readability, added distanceText per player instead of only one for all and added colors to the distance markers.

Let me know if you like it or want something changed ^^